### PR TITLE
Change Install syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Install
 ```bash
-bash -c "$(curl -s https://raw.githubusercontent.com/Henryws/Venom/master/install.sh)"
+curl -s https://raw.githubusercontent.com/Henryws/Venom/master/install.sh | bash
 ```
 
 ## Useful keybindings


### PR DESCRIPTION
The current syntax of installation won't work with some shells (like `fish`), use this universal syntax that will work in most shells.